### PR TITLE
feat: Handling `MileageTokenCreated` event

### DIFF
--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -31,5 +31,6 @@ export default (): any => ({
   },
   contract: {
     studentManager: process.env.STUDENT_MANAGER_CONTRACT_ADDRESS,
+    mileageTokenFactory: process.env.SW_MILEAGE_TOKEN_FACTORY_CONTRACT_ADDRESS,
   },
 });

--- a/src/config/module-options.ts
+++ b/src/config/module-options.ts
@@ -25,5 +25,6 @@ export const configModuleOptions: ConfigModuleOptions = {
     KAIROS_CHAIN_ID: Joi.number().required(),
     KAIROS_RPC_URL: Joi.string().required(),
     STUDENT_MANAGER_CONTRACT_ADDRESS: Joi.string().required(),
+    SW_MILEAGE_TOKEN_FACTORY_CONTRACT_ADDRESS: Joi.string().required(),
   }),
 };

--- a/src/modules/mileage-token/mileage-token.service.ts
+++ b/src/modules/mileage-token/mileage-token.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, InternalServerErrorException } from '@nestjs/common';
 import {
   CreateMileageTokenRequest,
   ActivateMileageTokenRequest,
@@ -66,5 +66,29 @@ export class MileageTokenService {
     }
 
     return mileageToken;
+  }
+
+  async handleMileageTokenCreatedEvent(
+    tokenAddress: Hex,
+    transactionHash: Hex,
+  ): Promise<{ success: boolean }> {
+    const mileageToken =
+      await this.mileageTokenRepository.getMileageTokenByTransactionHash(transactionHash);
+    if (!mileageToken) {
+      throw new NotFoundException('Mileage token not found');
+    }
+    const updatedMileageToken = await this.mileageTokenRepository.updateMileageToken(
+      mileageToken.id,
+      {
+        contract_address: tokenAddress,
+        transaction_status: TRANSACTION_STATUS.CONFIRMED,
+      },
+    );
+
+    if (!updatedMileageToken) {
+      throw new InternalServerErrorException('Failed to update mileage token');
+    }
+
+    return { success: true };
   }
 }

--- a/src/modules/mileage-token/mileage-token.service.ts
+++ b/src/modules/mileage-token/mileage-token.service.ts
@@ -27,8 +27,10 @@ export class MileageTokenService {
       transaction_status: TRANSACTION_STATUS.PROCESSING,
     };
 
+    // const pendingMileageToken =
+    //   await this.mileageTokenRepository.createMileageTokenInit(createMileageTokenParams);
     const pendingMileageToken =
-      await this.mileageTokenRepository.createMileageTokenInit(createMileageTokenParams);
+      await this.mileageTokenRepository.createMileageTokenInitNotNull(createMileageTokenParams);
 
     const txHash = await this.kaiaService.sendTransactionWithFeePayerSign(raw_transaction);
 

--- a/src/modules/mileage-token/repository/mileage-token.repository.ts
+++ b/src/modules/mileage-token/repository/mileage-token.repository.ts
@@ -18,6 +18,15 @@ export class MileageTokenRepository extends Repository<MileageToken> {
     return this.save(newMileageToken);
   }
 
+  async createMileageTokenInitNotNull(data: CreateMileageTokenParams): Promise<MileageToken> {
+    const newMileageToken = this.create({
+      ...data,
+      contract_address: '0x',
+      transaction_hash: '0x',
+    });
+    return this.save(newMileageToken);
+  }
+
   async updateMileageTokenTransactionHash(
     id: number,
     transaction_hash: string,

--- a/src/modules/mileage-token/repository/mileage-token.repository.ts
+++ b/src/modules/mileage-token/repository/mileage-token.repository.ts
@@ -49,4 +49,26 @@ export class MileageTokenRepository extends Repository<MileageToken> {
   async findByContractAddress(contractAddress: Hex): Promise<MileageToken | null> {
     return this.findOneBy({ contract_address: contractAddress });
   }
+
+  async getMileageTokenByTransactionHash(transaction_hash: Hex): Promise<MileageToken | null> {
+    const mileageToken = await this.findOneBy({ transaction_hash });
+    if (!mileageToken) {
+      return null;
+    }
+    return mileageToken;
+  }
+
+  async updateMileageToken(
+    id: number,
+    params: Partial<MileageToken>,
+  ): Promise<MileageToken | null> {
+    const mileageToken = await this.findOneBy({ id });
+    if (!mileageToken) {
+      return null;
+    }
+    return this.save({
+      ...mileageToken,
+      ...params,
+    });
+  }
 }

--- a/src/modules/polling/constants/event.enum.ts
+++ b/src/modules/polling/constants/event.enum.ts
@@ -8,4 +8,5 @@ export enum Event {
   MileageMinted = 'MileageMinted',
   AccountChanged = 'AccountChanged',
   AccountChangeConfirmed = 'AccountChangeConfirmed',
+  MileageTokenCreated = 'MileageTokenCreated',
 }

--- a/src/modules/polling/event.service.ts
+++ b/src/modules/polling/event.service.ts
@@ -1,7 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Log, decodeEventLog, Abi, Hex } from '@kaiachain/viem-ext';
+import { ConfigService } from '@nestjs/config';
 
 import StudentManagerAbi from '@/shared/constants/contract/StudentManager.abi.json';
+import SwMileageFactoryAbi from '@/shared/constants/contract/SwMileageTokenFactory.abi.json';
 import { AdminService } from '@/modules/admin/admin.service';
 import { StudentService } from '@/modules/student/student.service';
 
@@ -12,22 +14,30 @@ import { EventArgsMap, EventHandlers } from './event.types';
 import { MileageService } from '../mileage/mileage.service';
 import { MileagePointHistoryService } from '../mileage-point-history/mileage-point-history.service';
 import { WalletLostService } from '../wallet-lost/wallet-lost.service';
+import { MileageTokenService } from '../mileage-token/mileage-token.service';
 
 @Injectable()
 export class EventService {
   private readonly logger = new Logger(EventService.name);
   private studentManagerAbi: Abi;
+  private swMileageFactoryAbi: Abi;
   private readonly eventHandlers: EventHandlers;
+  private studentManagerContractAddress: Hex;
 
   constructor(
+    private readonly configService: ConfigService,
     private readonly eventLogRepository: EventLogRepository,
     private readonly adminService: AdminService,
     private readonly studentService: StudentService,
     private readonly mileageService: MileageService,
     private readonly mileagePointHistoryService: MileagePointHistoryService,
     private readonly walletLostService: WalletLostService,
+    private readonly mileageTokenService: MileageTokenService,
   ) {
     this.studentManagerAbi = StudentManagerAbi as Abi;
+    this.swMileageFactoryAbi = SwMileageFactoryAbi as Abi;
+    this.studentManagerContractAddress =
+      this.configService.getOrThrow<Hex>('contract.studentManager');
     this.eventHandlers = this.createEventHandlers();
   }
 
@@ -42,6 +52,7 @@ export class EventService {
       [Event.MileageMinted]: this.MileageMinted.bind(this),
       [Event.AccountChanged]: this.AccountChanged.bind(this),
       [Event.AccountChangeConfirmed]: this.AccountChangeConfirmed.bind(this),
+      [Event.MileageTokenCreated]: this.MileageTokenCreated.bind(this),
     };
   }
 
@@ -61,8 +72,12 @@ export class EventService {
 
   async routeEventHandler(log: Log) {
     try {
+      const isStudentManager =
+        log.address.toLowerCase() === this.studentManagerContractAddress.toLowerCase();
+      const abi = isStudentManager ? this.studentManagerAbi : this.swMileageFactoryAbi;
+
       const decodedLog = decodeEventLog({
-        abi: this.studentManagerAbi,
+        abi,
         data: log.data,
         topics: log.topics,
       });
@@ -199,6 +214,17 @@ export class EventService {
     const { student_id } = student;
 
     await this.studentService.handleAccountChangedEvent(student_id, target_account);
+  }
+
+  private async MileageTokenCreated(
+    args: EventArgsMap[Event.MileageTokenCreated],
+    transaction_hash: Hex,
+  ) {
+    const tokenAddress = (args as any).tokenAddress as Hex;
+
+    this.logger.debug('Handling MileageTokenCreated event...', args, tokenAddress);
+
+    await this.mileageTokenService.handleMileageTokenCreatedEvent(tokenAddress, transaction_hash);
   }
 
   private parseLogDataToSafeValue(data: any): string {

--- a/src/modules/polling/event.types.ts
+++ b/src/modules/polling/event.types.ts
@@ -9,6 +9,7 @@ type docHash = string;
 type amount = number;
 type reasonHash = string;
 type admin = Address;
+type tokenAddress = Address;
 
 export type EventArgsMap = {
   [Event.AdminAdded]: [account];
@@ -20,6 +21,7 @@ export type EventArgsMap = {
   [Event.MileageMinted]: [studentHash, account, admin, amount];
   [Event.AccountChanged]: [studentHash, account, targetAccount];
   [Event.AccountChangeConfirmed]: [studentHash, account, targetAccount];
+  [Event.MileageTokenCreated]: [tokenAddress];
 };
 
 export type EventHandler<E extends Event> = (

--- a/src/modules/polling/polling.module.ts
+++ b/src/modules/polling/polling.module.ts
@@ -14,6 +14,9 @@ import { StudentModule } from '../student/student.module';
 import { MileageModule } from '../mileage/mileage.module';
 import { MileagePointHistoryModule } from '../mileage-point-history/mileage-point-history.module';
 import { WalletLostModule } from '../wallet-lost/wallet-lost.module';
+import { MileageTokenService } from '../mileage-token/mileage-token.service';
+import { MileageTokenModule } from '../mileage-token/mileage-token.module';
+import { MileageTokenRepository } from '../mileage-token/repository/mileage-token.repository';
 
 @Module({
   imports: [
@@ -26,8 +29,16 @@ import { WalletLostModule } from '../wallet-lost/wallet-lost.module';
     MileageModule,
     MileagePointHistoryModule,
     WalletLostModule,
+    MileageTokenModule,
   ],
-  providers: [PollingService, EventService, EventLogRepository, BlockRepository],
+  providers: [
+    PollingService,
+    EventService,
+    MileageTokenService,
+    EventLogRepository,
+    BlockRepository,
+    MileageTokenRepository,
+  ],
   exports: [PollingService],
 })
 export class PollingModule {}

--- a/src/modules/polling/polling.service.ts
+++ b/src/modules/polling/polling.service.ts
@@ -13,6 +13,7 @@ export class PollingService implements OnModuleInit, OnModuleDestroy {
   private httpProvider: PublicClient<FallbackTransport>;
   private confirmationBlockCount = 3n;
   private studentManagerContractAddress: Hex;
+  private mileageTokenFactoryContractAddress: Hex;
 
   constructor(
     private readonly configService: ConfigService,
@@ -34,6 +35,9 @@ export class PollingService implements OnModuleInit, OnModuleDestroy {
 
     this.studentManagerContractAddress =
       this.configService.getOrThrow<Hex>('contract.studentManager');
+    this.mileageTokenFactoryContractAddress = this.configService.getOrThrow<Hex>(
+      'contract.mileageTokenFactory',
+    );
   }
 
   onModuleDestroy() {
@@ -85,7 +89,7 @@ export class PollingService implements OnModuleInit, OnModuleDestroy {
     this.logger.log(`Running confirmation poll from block ${fromBlock} to ${toBlock}`);
 
     const logs = await this.httpProvider.getLogs({
-      address: this.studentManagerContractAddress,
+      address: [this.studentManagerContractAddress, this.mileageTokenFactoryContractAddress],
       fromBlock,
       toBlock,
     });


### PR DESCRIPTION
- 환경 변수에서 토큰 factory 주소 사용하도록 추가 (`SW_MILEAGE_TOKEN_FACTORY_CONTRACT_ADDRESS`)
- `createMileageTokenInitNotNull` 메서드 추가
    - postgres 마이그레이션 후 스키마를 확인 해보니 mileage_token의 모든 column이 not null 이라 `/mileage-token` endpoint 에서 오류가 발생합니다.
    - 임시로 더미 값을 추가하는 메서드를 추가했으니 추후에 정리하면 될 것 같습니다.
- `getLogs` 메서드 호출시에 토큰 factory 주소의 로그도 같이 가져오도록 설정
- `MileageTokenCreated` 이벤트 수신시 db의 `contract_address` 업데이트 하도록 구현