### PR TITLE
feat: calc tx hash from rawTransaction

### DIFF
--- a/src/modules/kaia/kaia.service.ts
+++ b/src/modules/kaia/kaia.service.ts
@@ -1,7 +1,7 @@
 import { createWalletClient, Hex, http, kairos, privateKeyToAccount } from '@kaiachain/viem-ext';
 import { BadRequestException, Injectable, InternalServerErrorException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { Address, createPublicClient } from 'viem';
+import { Address, createPublicClient, keccak256, toBytes } from 'viem';
 
 import StudentManagerABI from '@/shared/constants/contract/StudentManager.abi.json';
 
@@ -70,6 +70,38 @@ export class KaiaService {
       console.error('Failed to send transaction:', error);
       throw new InternalServerErrorException(
         `Failed to send transaction: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+    }
+  }
+
+  async sendFeepayerSignedTransaction(feePayerSignedTx: Hex): Promise<Hex> {
+    try {
+      const sentFeePayerTx = await this.feePayerClient.request({
+        method: 'klay_sendRawTransaction',
+        params: [feePayerSignedTx],
+      });
+      return sentFeePayerTx as Hex;
+    } catch (error) {
+      console.error('Failed to send transaction:', error);
+      throw new InternalServerErrorException(
+        `Failed to send transaction: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+    }
+  }
+
+  async calcTxHashFromRawTransaction(
+    rawTransaction: Hex,
+  ): Promise<{ txHash: Hex; feePayerSignedTx: Hex }> {
+    try {
+      const feePayerSignedTx = (await this.feePayerClient.signTransactionAsFeePayer(
+        rawTransaction,
+      )) as Hex;
+      const txHash = keccak256(toBytes(feePayerSignedTx as Hex));
+      return { txHash, feePayerSignedTx };
+    } catch (error) {
+      console.error('Failed to calculate transaction hash:', error);
+      throw new InternalServerErrorException(
+        `Failed to calculate transaction hash: ${error instanceof Error ? error.message : 'Unknown error'}`,
       );
     }
   }

--- a/src/modules/mileage-token/mileage-token.service.ts
+++ b/src/modules/mileage-token/mileage-token.service.ts
@@ -39,12 +39,16 @@ export class MileageTokenService {
       const pendingMileageToken =
         await this.mileageTokenRepository.createMileageTokenInit(createMileageTokenParams);
 
-      const txHash = await this.kaiaService.sendTransactionWithFeePayerSign(rawTransaction);
-
-      return await this.mileageTokenRepository.updateMileageTokenTransactionHash(
+      const { txHash, feePayerSignedTx } =
+        await this.kaiaService.calcTxHashFromRawTransaction(rawTransaction);
+      const mileageToken = await this.mileageTokenRepository.updateMileageTokenTransactionHash(
         pendingMileageToken.id,
         txHash,
       );
+
+      await this.kaiaService.sendFeepayerSignedTransaction(feePayerSignedTx);
+
+      return mileageToken;
     } catch (error) {
       console.error('Failed to create mileage token:', error);
       throw new InternalServerErrorException('Failed to create mileage token');

--- a/src/modules/mileage/mileage.service.ts
+++ b/src/modules/mileage/mileage.service.ts
@@ -1,4 +1,4 @@
-import { Hex } from '@kaiachain/viem-ext';
+import { Hex, keccak256, toBytes } from '@kaiachain/viem-ext';
 import {
   BadRequestException,
   ForbiddenException,
@@ -92,7 +92,9 @@ export class MileageService {
 
     const newMileage = await this.mileageRepository.createMileageInit(mileageInitParams);
 
-    const txHash = await this.kaiaService.sendTransactionWithFeePayerSign(rawTransaction as Hex);
+    const { txHash, feePayerSignedTx } = await this.kaiaService.calcTxHashFromRawTransaction(
+      rawTransaction as Hex,
+    );
 
     const uploadedFiles: CreateMileageFileParams[] = mileageFiles.map((file) => {
       const serverUrl = this.configService.get('app.publicFileUrl');
@@ -107,6 +109,8 @@ export class MileageService {
     await this.mileageFileRepository.createMileageFiles(uploadedFiles);
 
     await this.mileageRepository.updatePendingMileage(newMileage.id, txHash);
+
+    await this.kaiaService.sendFeepayerSignedTransaction(feePayerSignedTx);
 
     return {
       success: true,
@@ -180,7 +184,9 @@ export class MileageService {
       TRANSACTION_STATUS.PROCESSING,
     );
 
-    const txHash = await this.kaiaService.sendTransactionWithFeePayerSign(rawTransaction);
+    // const txHash = await this.kaiaService.sendTransactionWithFeePayerSign(rawTransaction);
+    const { txHash, feePayerSignedTx } =
+      await this.kaiaService.calcTxHashFromRawTransaction(rawTransaction);
 
     await this.mileagePointHistoryService.createMileagePointHistoryInit({
       type: MILEAGE_POINT_HISTORY_TYPE.MILEAGE_APPROVED,
@@ -192,6 +198,8 @@ export class MileageService {
       transactionHash: txHash,
       mileage,
     });
+
+    await this.kaiaService.sendFeepayerSignedTransaction(feePayerSignedTx);
 
     return {
       success: true,
@@ -236,7 +244,9 @@ export class MileageService {
     const currentToken =
       await this.mileageTokenService.getMileageTokenByContractAddress(currentTokenAddress);
 
-    const txHash = await this.kaiaService.sendTransactionWithFeePayerSign(rawTransaction);
+    // const txHash = await this.kaiaService.sendTransactionWithFeePayerSign(rawTransaction);
+    const { txHash, feePayerSignedTx } =
+      await this.kaiaService.calcTxHashFromRawTransaction(rawTransaction);
 
     await this.mileagePointHistoryService.createMileagePointHistoryInit({
       type: MILEAGE_POINT_HISTORY_TYPE.MILEAGE_MINTED,
@@ -249,6 +259,8 @@ export class MileageService {
       note,
       mileage,
     });
+
+    await this.kaiaService.sendFeepayerSignedTransaction(feePayerSignedTx);
 
     return {
       success: true,
@@ -267,7 +279,10 @@ export class MileageService {
     const currentToken =
       await this.mileageTokenService.getMileageTokenByContractAddress(currentTokenAddress);
 
-    const txHash = await this.kaiaService.sendTransactionWithFeePayerSign(rawTransaction);
+    // const txHash = await this.kaiaService.sendTransactionWithFeePayerSign(rawTransaction);
+
+    const { txHash, feePayerSignedTx } =
+      await this.kaiaService.calcTxHashFromRawTransaction(rawTransaction);
 
     await this.mileagePointHistoryService.createMileagePointHistoryInit({
       type: MILEAGE_POINT_HISTORY_TYPE.MILEAGE_BURNED,
@@ -280,6 +295,8 @@ export class MileageService {
       note,
       mileage,
     });
+
+    await this.kaiaService.sendFeepayerSignedTransaction(feePayerSignedTx);
 
     return {
       success: true,

--- a/src/modules/student/student.service.ts
+++ b/src/modules/student/student.service.ts
@@ -62,7 +62,10 @@ export class StudentService {
 
     const student = await this.studentRepository.createStudent(newStudentParams);
 
-    const txHash = await this.kaiaService.sendTransactionWithFeePayerSign(request.rawTransaction);
+    // const txHash = await this.kaiaService.sendTransactionWithFeePayerSign(request.rawTransaction);
+    const { txHash, feePayerSignedTx } = await this.kaiaService.calcTxHashFromRawTransaction(
+      request.rawTransaction,
+    );
 
     const updatedStudent = await this.studentRepository.updateStudent(student.student_id, {
       transaction_hash: txHash,
@@ -71,6 +74,11 @@ export class StudentService {
     if (!updatedStudent) {
       throw new NotFoundException('학생을 찾을 수 없습니다.');
     }
+
+    console.log(`txHash: ${txHash}`);
+
+    const _hash = await this.kaiaService.sendFeepayerSignedTransaction(feePayerSignedTx);
+    console.log(`_hash: ${_hash}`);
 
     return updatedStudent;
   }
@@ -105,7 +113,9 @@ export class StudentService {
       student_id: studentId,
       name,
     };
+    console.log('getStudentsParams:', getStudentsParams);
     const [students, total] = await this.studentRepository.getStudents(getStudentsParams);
+    console.log('students:', students, 'total:', total);
 
     return { students, total };
   }

--- a/src/modules/wallet-lost/wallet-lost.service.ts
+++ b/src/modules/wallet-lost/wallet-lost.service.ts
@@ -90,7 +90,9 @@ export class WalletLostService {
       throw new BadRequestException('Wallet lost is not pending');
     }
 
-    const txHash = await this.kaiaService.sendTransactionWithFeePayerSign(rawTransaction);
+    // const txHash = await this.kaiaService.sendTransactionWithFeePayerSign(rawTransaction);
+    const { txHash, feePayerSignedTx } =
+      await this.kaiaService.calcTxHashFromRawTransaction(rawTransaction);
 
     const updatedWalletLost = await this.walletLostRepository.updateWallet(id, {
       transaction_hash: txHash,
@@ -100,6 +102,8 @@ export class WalletLostService {
     if (!updatedWalletLost) {
       throw new InternalServerErrorException('Failed to update wallet lost');
     }
+
+    await this.kaiaService.sendFeepayerSignedTransaction(feePayerSignedTx);
 
     return updatedWalletLost;
   }


### PR DESCRIPTION
- txHash를 트랜잭션을 rpc에 전달하기 전에 계산하는 로직 추가
    - kaia.service에 `sendFeepayerSignedTransaction`, `calcTxHashFromRawTransaction` 추가
- 기존 코드 중에 (tx 전송 -> txHash를 db에 추가) 패턴을 사용하는 기존 로직을 (txHash 계산 -> db 추가 -> tx 전송) 패턴으로 변경
    - 순서만 변경되었기 때문에 특별한 side effect는 없을 것 같습니다.