### PR TITLE
refactor: add transaction validation

### DIFF
--- a/src/modules/kaia/kaia.service.ts
+++ b/src/modules/kaia/kaia.service.ts
@@ -2,6 +2,7 @@ import { createWalletClient, Hex, http, kairos, privateKeyToAccount } from '@kai
 import { BadRequestException, Injectable, InternalServerErrorException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Address, createPublicClient, keccak256, toBytes } from 'viem';
+import { decodeFunctionData, parseTransaction } from '@kaiachain/viem-ext';
 
 import StudentManagerABI from '@/shared/constants/contract/StudentManager.abi.json';
 
@@ -102,6 +103,125 @@ export class KaiaService {
       console.error('Failed to calculate transaction hash:', error);
       throw new InternalServerErrorException(
         `Failed to calculate transaction hash: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+    }
+  }
+
+  async validateStudentManagerTransaction(
+    rawTransaction: Hex,
+    expectedWalletAddress: Address,
+    expectedFunctionName: string,
+    expectedArg0: string,
+  ): Promise<void> {
+    // 1. from 주소가 서버에 전송된 지갑 주소(혹은 등록된 주소와 같은지 확인)
+    // 2. to 주소가 StudentManager 컨트랙트 주소와 같은지 확인
+    // 3. 호출하는 함수 이름이 expectedFunctionName과 같은지 확인 (e.g., submitDocument)
+    // 4. 호출하는 함수의 첫번째 인자가 expectedArg0와 같은지 확인 (e.g., submitDocument(docHash) -> docHash is expected arg0)
+    try {
+      const txData = await this.parseRawTransaction(rawTransaction);
+      // console.log('txData', txData);
+      
+      if (txData.from.toLowerCase() !== expectedWalletAddress.toLowerCase()) {
+        throw new BadRequestException(
+          `Transaction sender address mismatch. Expected: ${expectedWalletAddress}, got: ${txData.from}`,
+        );
+      }
+
+      if (txData.to.toLowerCase() !== this.studentManagerContractAddress.toLowerCase()) {
+        throw new BadRequestException(
+          `Invalid contract address. Expected StudentManager contract: ${this.studentManagerContractAddress}, got: ${txData.to}`,
+        );
+      }
+
+      const decodedData = decodeFunctionData({
+        abi: StudentManagerABI,
+        data: txData.data,
+      });
+
+      if (decodedData.functionName !== expectedFunctionName) {
+        throw new BadRequestException(
+          `Function name mismatch. Expected: ${expectedFunctionName}, got: ${decodedData.functionName}`,
+        );
+      }
+
+      if (!decodedData.args || decodedData.args.length === 0) {
+        throw new BadRequestException(`No arguments found in ${expectedFunctionName} function call`);
+      }
+      
+      const firstArg = decodedData.args[0] as string;
+      if (firstArg !== expectedArg0) {
+        throw new BadRequestException(
+          `First argument mismatch in ${expectedFunctionName}. Expected: ${expectedArg0}, got: ${firstArg}`,
+        );
+      }
+
+    } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
+      throw new BadRequestException(
+        `Transaction validation failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+    }
+  }
+  
+  async validateStudentManagerFunction(parsedRawTransaction: Hex, expectedFunctionName: string) {
+    // tx가 호출하는 컨트랙트 주소 (tx.to)와 호출하는 함수 이름을 검증
+    // validateStudentManagerTransaction 에서는 tx.from 과 컨트랙트 호출 인자까지 검증
+    try {
+      const txData = await this.parseRawTransaction(parsedRawTransaction);
+      if (txData.to.toLowerCase() !== this.studentManagerContractAddress.toLowerCase()) {
+        throw new BadRequestException(
+          `Invalid contract address. Expected StudentManager contract: ${this.studentManagerContractAddress}, got: ${txData.to}`,
+        );
+      }
+      const decodedData = decodeFunctionData({
+        abi: StudentManagerABI,
+        data: txData.data,
+      });
+      if (decodedData.functionName !== expectedFunctionName) {
+        throw new BadRequestException(
+          `Function name mismatch. Expected: ${expectedFunctionName}, got: ${decodedData.functionName}`,
+        );
+      }
+    } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
+      throw new BadRequestException(
+        `Function validation failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+    }
+  }
+
+  private async parseRawTransaction(rawTransaction: Hex): Promise<{
+    from: Address;
+    to: Address;
+    data: Hex;
+  }> {
+    try {
+      const parsedTx = parseTransaction(rawTransaction);
+
+      if (!parsedTx.from) {
+        throw new InternalServerErrorException('Transaction does not have a from address');
+      }
+
+      if (!parsedTx.to) {
+        throw new InternalServerErrorException('Transaction does not have a to address');
+      }
+
+      if (!parsedTx.data) {
+        throw new InternalServerErrorException('Transaction does not have data field');
+      }
+
+      return {
+        from: parsedTx.from as Hex,
+        to: parsedTx.to as Hex,
+        data: parsedTx.data as Hex,
+      };
+    } catch (error) {
+      throw new InternalServerErrorException(
+        `Failed to parse raw transaction: ${error instanceof Error ? error.message : 'Unknown error'}`,
       );
     }
   }

--- a/src/modules/mileage/mileage.service.ts
+++ b/src/modules/mileage/mileage.service.ts
@@ -321,13 +321,10 @@ export class MileageService {
 
   async handleDocSubmittedEvent(
     doc_index: number,
-    doc_hash: string,
+    transaction_hash: Hex,
   ): Promise<{ success: boolean }> {
-    if (!doc_hash) {
-      throw new BadRequestException('잘못된 문서 해시입니다.');
-    }
-
-    const mileage = await this.mileageRepository.findMileageByDocHash(doc_hash);
+    // const mileage = await this.mileageRepository.findMileageByDocHash(doc_hash);
+    const mileage = await this.mileageRepository.findMileageByTransactionHash(transaction_hash);
     if (!mileage) {
       throw new NotFoundException('Mileage not found');
     }

--- a/src/modules/mileage/mileage.service.ts
+++ b/src/modules/mileage/mileage.service.ts
@@ -79,6 +79,14 @@ export class MileageService {
       throw new NotFoundException('Student not found');
     }
 
+    // validate the raw transaction before fee payer signing
+    await this.kaiaService.validateStudentManagerTransaction(
+      rawTransaction as Hex,
+      student.wallet_address as Hex,
+      'submitDocument',
+      input.docHash,
+    );
+
     const mileageInitParams: CreateMileageInitParams = {
       mileage_category_name: input.mileageCategoryName,
       mileage_activity_name: mileageActivity.name,

--- a/src/modules/mileage/repository/mileage.repository.ts
+++ b/src/modules/mileage/repository/mileage.repository.ts
@@ -83,6 +83,14 @@ export class MileageRepository extends Repository<Mileage> {
     return mileage;
   }
 
+  async findMileageByTransactionHash(transaction_hash: string): Promise<Mileage | null> {
+    const mileage = await this.findOneBy({ transaction_hash });
+    if (!mileage) {
+      return null;
+    }
+    return mileage;
+  }
+
   async updateMileageStatus(
     id: number,
     status: MILEAGE_STATUS,

--- a/src/modules/polling/event.service.ts
+++ b/src/modules/polling/event.service.ts
@@ -158,12 +158,11 @@ export class EventService {
     await this.studentService.handleStudentRegisteredEvent(student_hash);
   }
 
-  private async DocSubmitted(args: EventArgsMap[Event.DocSubmitted]) {
+  private async DocSubmitted(args: EventArgsMap[Event.DocSubmitted], transaction_hash: Hex) {
     this.logger.debug('Handling DocSubmitted event...', args);
     const docuemnt_index = Number(args.documentIndex);
-    const doc_hash = args.docHash;
 
-    await this.mileageService.handleDocSubmittedEvent(docuemnt_index, doc_hash);
+    await this.mileageService.handleDocSubmittedEvent(docuemnt_index, transaction_hash);
   }
 
   private async DocApproved(args: EventArgsMap[Event.DocApproved], transaction_hash: Hex) {

--- a/src/modules/student/student.service.ts
+++ b/src/modules/student/student.service.ts
@@ -60,6 +60,14 @@ export class StudentService {
       student_hash: request.studentHash,
     };
 
+    // validate the raw transaction before fee payer signing
+    await this.kaiaService.validateStudentManagerTransaction(
+      request.rawTransaction,
+      walletAddress,
+      'registerStudent',
+      request.studentHash,
+    );
+
     const student = await this.studentRepository.createStudent(newStudentParams);
 
     // const txHash = await this.kaiaService.sendTransactionWithFeePayerSign(request.rawTransaction);
@@ -128,8 +136,10 @@ export class StudentService {
     if (!student) {
       throw new NotFoundException('학생을 찾을 수 없습니다.');
     }
-
-    await this.kaiaService.sendTransactionWithFeePayerSign(request.rawTransaction);
+    
+    await this.kaiaService.validateStudentManagerFunction(request.rawTransaction, 'proposeAccountChange');
+    
+    const txHash = await this.kaiaService.sendTransactionWithFeePayerSign(request.rawTransaction);
 
     return {
       success: true,
@@ -145,6 +155,7 @@ export class StudentService {
       throw new NotFoundException('학생을 찾을 수 없습니다.');
     }
 
+    await this.kaiaService.validateStudentManagerFunction(request.rawTransaction, 'confirmAccountChange');
     await this.kaiaService.sendTransactionWithFeePayerSign(request.rawTransaction);
 
     return {


### PR DESCRIPTION
(1) 서버에서 받은 signedTx가 정상적인지 검증하기 위해 `KaiaService`에 아래 3가지 함수를 추가했습니다.
- `validateStudentManagerTransaction`
    - 트랜잭션 필드 중 `from`이 등록된 지갑 주소이고 `to`가 StudentManager 컨트랙트 주소인지 체크
    - 호출하는 함수의 이름이 적절하고 첫 번째 인자가 정상적인지 체크
- `validateStudentManagerFunction`
    - `to`가 StudentManager 컨트랙트 주소이고 호출된 함수 이름이 적절한지 체크
- `parseRawTransaction`
    -  서명된 rawTx를 파싱

(2) 일반 학생이 호출 하는 부분은 검증 처리가 필요할 것으로 보여서 `registerStudent`, `submitDocument`, `proposeAccountChange`, `confirmAccountChange` 함수 트랜잭션을 처리하는 부분에  (1)의 함수를 이용하여 검증을 추가했습니다.
- `StudentService`의 `registerStudent`, `MileageService`의 `submitDocument` 처리 부분은 `validateStudentManagerTransaction` 함수 사용
-  나머지 두 함수를 처리하는 부분에는 `validateStudentManagerFunction` 함수 사용

(3) `submitDocument` 호출하고 poller에서 `DocSubmitted` 이벤트를 받는 때, `docHash`가 아니라 `txHash`를 이용하여 매칭하도록 수정